### PR TITLE
RGBTransform fix gamma adjustment of green, blue always taking red value

### DIFF
--- a/libsrc/utils/RgbTransform.cpp
+++ b/libsrc/utils/RgbTransform.cpp
@@ -144,8 +144,8 @@ void RgbTransform::transform(uint8_t & red, uint8_t & green, uint8_t & blue)
 {
 	// apply gamma
 	red   = _mappingR[red];
-	green = _mappingR[green];
-	blue  = _mappingR[blue];
+	green = _mappingG[green];
+	blue  = _mappingB[blue];
 
 	// apply brightnesss
 	int rgbSum = red+green+blue;


### PR DESCRIPTION
This fixes #493 and is also present on the latest beta rework branch.


**1.** Tell us something about your changes.

**2.** If this changes affect the .conf file. Please provide the changed section

**3.** Reference an issue (optional)

Note: For further discussions use our forum: forum.hyperion-project.org

